### PR TITLE
fix libxslt build for mac

### DIFF
--- a/deps/libxslt/config/mac/ia32/config.h
+++ b/deps/libxslt/config/mac/ia32/config.h
@@ -8,7 +8,7 @@
 #define HAVE_ASCTIME 1
 
 /* Define to 1 if you have the `clock_gettime' function. */
-#define HAVE_CLOCK_GETTIME 1
+#undef HAVE_CLOCK_GETTIME
 
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #define HAVE_DLFCN_H 1

--- a/deps/libxslt/config/mac/x64/config.h
+++ b/deps/libxslt/config/mac/x64/config.h
@@ -8,7 +8,7 @@
 #define HAVE_ASCTIME 1
 
 /* Define to 1 if you have the `clock_gettime' function. */
-#define HAVE_CLOCK_GETTIME 1
+#undef HAVE_CLOCK_GETTIME
 
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #define HAVE_DLFCN_H 1


### PR DESCRIPTION
Mac does not have `HAVE_CLOCK_GETTIME`.
