### PR TITLE
Fix string buffer length computation.

### DIFF
--- a/src/node_libxslt.cc
+++ b/src/node_libxslt.cc
@@ -92,7 +92,7 @@ char** PrepareParams(Handle<Array> array) {
     memset(params, 0, sizeof(char *) * (array->Length() + 1));
     for (int i = 0; i < array->Length(); i++) {
         Local<String> param = array->Get(NanNew<Integer>(i))->ToString();
-        params[i] = (char *)malloc(sizeof(char) * (param->Length() + 1));
+        params[i] = (char *)malloc(sizeof(char) * (param->Utf8Length() + 1));
         param->WriteUtf8(params[i]);
     }
     return params;


### PR DESCRIPTION
Before calling WriteUtf8, the length should be computed using Utf8Length,
not just Length.