### PR TITLE
Thread local memory adjustments

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "bindings": "~1.2.1",
-    "libxmljs": "^0.11.1",
+    "libxmljs": "git://github.com/gagern/libxmljs.git#52c5eba92920a4f1335d",
     "nan": "~1.2.0"
   },
   "devDependencies": {

--- a/src/node_libxslt.cc
+++ b/src/node_libxslt.cc
@@ -46,6 +46,7 @@ class StylesheetWorker : public NanAsyncWorker {
   // here, so everything we need for input and output
   // should go on `this`.
   void Execute () {
+    libxmljs::WorkerSentinel workerSentinel(workerParent);
     result = xsltParseStylesheetDoc(doc->xml_obj);
   }
 
@@ -65,6 +66,7 @@ class StylesheetWorker : public NanAsyncWorker {
   };
 
  private:
+  libxmljs::WorkerParent workerParent;
   libxmljs::XmlDocument* doc;
   xsltStylesheetPtr result;
 };
@@ -140,6 +142,7 @@ class ApplyWorker : public NanAsyncWorker {
   // here, so everything we need for input and output
   // should go on `this`.
   void Execute () {
+    libxmljs::WorkerSentinel workerSentinel(workerParent);
     result = xsltApplyStylesheet(stylesheet->stylesheet_obj, docSource->xml_obj, (const char **)params);
   }
 
@@ -171,6 +174,7 @@ class ApplyWorker : public NanAsyncWorker {
   };
 
  private:
+  libxmljs::WorkerParent workerParent;
   Stylesheet* stylesheet;
   libxmljs::XmlDocument* docSource;
   char** params;


### PR DESCRIPTION
This is my stab at making libxmljs usable in a thread-safe manner, as discussed in #9 and polotek/libxmljs#296. And while the corresponding merge request polotek/libxmljs#300 is still open, things appear to work reasonably well. So if you want to support Node 0.12 *now*, without waiting on libxmljs master, you can use this. Of course, there is a danger that upstream decides to follow some other approach, and this commit here will have to be completely reverted. Up to you.

In any case, since the commit id is hardcoded into the dependency, this is only a temporary solution until we have some upstream which officially supports thread-safety one way or another.