### PR TITLE
Switch to newer libxmljs development version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "bindings": "~1.2.1",
-    "libxmljs": "git://github.com/gagern/libxmljs.git#52c5eba92920a4f1335d",
+    "libxmljs": "git://github.com/gagern/libxmljs.git#d44be6148f05351eb76a",
     "nan": "~1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The old version didn't make use of pthreads, therefore didn't use any locks and therefore wasn't thread-safe. gagern/libxmljs@0ebc0605ad46321506cb172ee8d7e01271109572 fixes that problem, and is included in the gagern/libxmljs@d44be6148f05351eb76aaa92fc8fab4be80b295c I'm suggesting here. This is still not officially merged. See polotek/libxmljs#296 for discussion of this problem and polotek/libxmljs#300 for this specific attempt at a solution and any future commits I might have to add to this.