### PR TITLE
Switch to libxmljs-mt fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "bindings": "~1.2.1",
-    "libxmljs": "git://github.com/gagern/libxmljs.git#563f72e0e537eb85527e8609fe3b3d8215176f7f",
+    "libxmljs-mt": "^0.14.2",
     "nan": "~1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I've now gone ahead and officially forked libxmljs. So in the future, you shouldn't be troubled by any restrictions due to github dependencies. This should make installing the package easier. I still hope that my fork is a temporary solution, though.