### PR TITLE
Advertise libxslt include directories correctly

### DIFF
--- a/deps/libxslt.gyp
+++ b/deps/libxslt.gyp
@@ -66,7 +66,12 @@
       },
       'direct_dependent_settings': {
         'defines': ['LIBXSLT_STATIC'],
-        'include_dirs': ['.', '<@(xmljs_include_dirs)', 'config/<(OS)/<(target_arch)'],
+        'include_dirs': [
+          'libxslt/',
+          # platform and arch-specific headers
+          'libxslt.config/<(OS)/<(target_arch)',
+          '<@(xmljs_include_dirs)'
+        ],
       }
     },
     {


### PR DESCRIPTION
I forgot to adjust the advertised include directories when I implemented the switch to a git submodule. Sorry.

This should fix issue #15.