### PR TITLE
Include the libxml.conf include directory

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -4,7 +4,8 @@
     'node_xmljs': '<!(node -p -e "require(\'path\').dirname(require.resolve(\'libxmljs-mt\'))")',
     'xmljs_include_dirs': [
       '<(node_xmljs)/src/',
-      '<(node_xmljs)/vendor/libxml/include'
+      '<(node_xmljs)/vendor/libxml/include',
+      '<(node_xmljs)/vendor/libxml.conf/include'
     ],
     'conditions': [
       ['OS=="win"', {


### PR DESCRIPTION
This is where libxmljs-mt keeps its xmlversion.h header file, see #20.