### PR TITLE
Let the stylesheet object own the underlying xml document

### DIFF
--- a/src/stylesheet.cc
+++ b/src/stylesheet.cc
@@ -11,10 +11,7 @@ Stylesheet::Stylesheet(xsltStylesheetPtr stylesheetPtr) : stylesheet_obj(stylesh
 
 Stylesheet::~Stylesheet()
 {
-    // TODO, potential memory leak here ?
-    // We can't free the stylesheet as the xml doc inside was probably
-    // already deleted by garbage collector and this results in segfaults
-    //xsltFreeStylesheet(stylesheet_obj);
+    xsltFreeStylesheet(stylesheet_obj);
 }
 
 void Stylesheet::Init(Handle<Object> exports) {


### PR DESCRIPTION
Apparently libxslt stylesheets always assume ownership of their underlying
xml document.  There appears to be no API for freeing the stylesheet without
freeing the document.  Therefore, we have to ensure that the xml document
from which we parse the stylesheet will not be freed by the v8 garbage
collector.  We can achieve this by replacing the document inside the
libxmljs wrapper.  We change that wrapper to contain an empty document
instead, so its destructor will work just fine even though we essentially
steal the document from its wrapper.

An alternative would have been to clone the document, and refer to a clone
instead.  But I couldn't find an easy API for cloning either, and the most
common use case is that the document is used to construct the stylesheet but
for nothing else after that.  So the chosen approach optimizes for that most
common case by avoiding unneccessary duplication.

This should fix #28, hopefully for good this time.