### PR TITLE
Make builds on AppVeyor succeed

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,18 +1,19 @@
 environment:
-  matrix:
-    - nodejs_version: 0.10.36
-      platform: x86
-      msvs_toolset: 12
+ matrix:
+  - nodejs_version: "4"
 
-os: Visual Studio 2014 CTP4
+os: Visual Studio 2015
 
 install:
+  - ps: Install-Product node $env:nodejs_version
+  - node --version
+  - npm --version
   - git submodule update --init --recursive
+
+build_script:
   - npm install
+
+test_script:
   - npm test
 
-build: OFF
-
-test: OFF
-
-deploy: OFF
+deploy: off

--- a/deps/libxslt.config/win/ia32/libxslt/xsltconfig.h
+++ b/deps/libxslt.config/win/ia32/libxslt/xsltconfig.h
@@ -116,11 +116,11 @@ extern "C" {
  * Whether module support is configured into libxslt
  * Note: no default module path for win32 platforms
  */
-#if 0
+#if 1
 #ifndef WITH_MODULES
 #define WITH_MODULES
 #endif
-#define LIBXSLT_DEFAULT_PLUGINS_PATH() "/usr/local/lib/libxslt-plugins"
+#define LIBXSLT_DEFAULT_PLUGINS_PATH() NULL
 #endif
 
 /**

--- a/deps/libxslt.config/win/x64/libxslt/xsltconfig.h
+++ b/deps/libxslt.config/win/x64/libxslt/xsltconfig.h
@@ -116,11 +116,11 @@ extern "C" {
  * Whether module support is configured into libxslt
  * Note: no default module path for win32 platforms
  */
-#if 0
+#if 1
 #ifndef WITH_MODULES
 #define WITH_MODULES
 #endif
-#define LIBXSLT_DEFAULT_PLUGINS_PATH() "/usr/local/lib/libxslt-plugins"
+#define LIBXSLT_DEFAULT_PLUGINS_PATH() NULL
 #endif
 
 /**

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "license": "MIT",
   "dependencies": {
     "bindings": "~1.2.1",
-    "libxmljs-mt": "0.14.5",
+    "libxmljs-mt": "0.15.2",
     "nan": "^2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
To successfully build on windows, we have to use a newer version of `libxmljs-mt` which avoids defining the `snprintf` function as a macro and does ddl-export its api.

To make the `nodejs_version` setting have any effect we also need to install node ourself.  See http://www.appveyor.com/docs/lang/nodejs-iojs for that.

We need to define `LIBXSLT_DEFAULT_PLUGINS_PATH` to avoid an unresolved symbol, but we may define it to be `NULL` which seems to be what `deps/libxslt/wind32/configure.js` would be doing as well.

This should fix #27, and get rid of the annoying AppVeyor error messages on every pull request.