### PR TITLE
use double quotes to wrap string parameters by default and provide su…

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,10 +109,11 @@ Stylesheet.prototype.apply = function(source, params, options, callback) {
 	params = params || {};
 	options = options || {};
 
-	for(var p in params) {
-		// string parameters must be surrounded by quotes to be usable by the stylesheet
-		if (typeof params[p] === 'string') params[p] = '\'' + params[p] + '\'';
-	}
+	if (!options.noWrapParams)
+	  for(var p in params) {
+	    // string parameters must be surrounded by quotes to be usable by the stylesheet
+	    if (typeof params[p] === 'string') params[p] = '"' + params[p] + '"';
+	  }
 
 	// Output format can be passed as explicit option or
 	// is implicit and mapped to the input format

--- a/test/libxslt.js
+++ b/test/libxslt.js
@@ -249,6 +249,30 @@ describe('node-libxslt', function() {
 		});
 	});
 
+	describe('handle quotes in strings', function() {
+
+		it('should avoid conflict with xpath single quote by using double-quotes', function() {
+			var data='<root/>';
+			var  xslDoc = libxslt.parse(fs.readFileSync('test/resources/handle-quotes-in-string-params.xsl', 'utf8'));
+			var result = xslDoc.apply(data,{strParam:"/root/item[@id='123']"});
+			result.should.match(/strParam:\/root\/item\[@id='123'\]/);
+		});
+
+	});
+
+	describe('no params wrap', function() {
+
+		it('should bypass parameter string wrap and deliver xpath expressions for nodesets', function() {
+			var data='<root><item id="123">Ok 123</item><item id="321"/><other/></root>';
+			var  xslDoc = libxslt.parse(fs.readFileSync('test/resources/use-xpath-params.xsl', 'utf8'));
+			var result = xslDoc.apply(data,{at:"/root/item[@id='123']",testName:"'testing xpath selectors'"},{noWrapParams:true});
+			result.should.match(/testing xpath selectors/);
+			result.should.match(/#selected nodes:1/);
+			result.should.match(/Node \[item id:123\] was selected./);
+		});
+
+	});
+
 	describe('libexslt bindings', function(){
 		it('should expose EXSLT functions', function(callback){
 			libxslt.parseFile('test/resources/min-value.xsl', function(err, stylesheet){

--- a/test/resources/handle-quotes-in-string-params.xsl
+++ b/test/resources/handle-quotes-in-string-params.xsl
@@ -1,0 +1,9 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <xsl:output method="text" omit-xml-declaration="yes" indent="no"/>
+  
+  <xsl:template match="root">
+    strParam:<xsl:value-of select="$strParam"/>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/test/resources/use-xpath-params.xsl
+++ b/test/resources/use-xpath-params.xsl
@@ -1,0 +1,16 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <xsl:output method="text" omit-xml-declaration="yes" indent="no"/>
+  <!-- $at should be a xpath "string" parameter (not wrapped) and should result in a nodeset inside this xsl -->
+
+  <xsl:template match="root">
+    <xsl:value-of select="$testName"/>
+    #selected nodes:<xsl:value-of select="count($at)"/>
+    <xsl:apply-templates select="$at" mode="sel"/>
+  </xsl:template>
+
+  <xsl:template match="*" mode="sel">
+    Node [<xsl:value-of select="name()"/> id:<xsl:value-of select="@id"/>] was selected.
+  </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
…pport for noWrapParams option

as refered in https://github.com/albanm/node-libxslt/issues/39