### PR TITLE
Free result xml strings after constructing v8 strings

### DIFF
--- a/src/node_libxslt.cc
+++ b/src/node_libxslt.cc
@@ -126,8 +126,8 @@ NAN_METHOD(ApplySync) {
       int len;
       xsltSaveResultToString(&resStr,&len,result,stylesheet->stylesheet_obj);
       xmlFreeDoc(result);
-      info.GetReturnValue().Set(Nan::New<String>((char*)resStr).ToLocalChecked());
-      xmlFree(resStr);
+      info.GetReturnValue().Set(Nan::New<String>(resStr ? (char*)resStr : "").ToLocalChecked());
+      if (resStr) xmlFree(resStr);
     } else {
       // Fill a result libxmljs document.
       // for some obscure reason I didn't manage to create a new libxmljs document in applySync,
@@ -189,8 +189,8 @@ class ApplyWorker : public Nan::AsyncWorker {
       int len;
       int cnt=xsltSaveResultToString(&resStr,&len,result,stylesheet->stylesheet_obj);
       xmlFreeDoc(result);
-      Local<Value> argv[] = { Nan::Null(), Nan::New<String>((char*)resStr).ToLocalChecked()};
-      xmlFree(resStr);
+      Local<Value> argv[] = { Nan::Null(), Nan::New<String>(resStr ? (char*)resStr : "").ToLocalChecked()};
+      if (resStr) xmlFree(resStr);
       freeArray(params, paramsLength);
       callback->Call(2, argv);
     }

--- a/src/node_libxslt.cc
+++ b/src/node_libxslt.cc
@@ -127,6 +127,7 @@ NAN_METHOD(ApplySync) {
       xsltSaveResultToString(&resStr,&len,result,stylesheet->stylesheet_obj);
       xmlFreeDoc(result);
       info.GetReturnValue().Set(Nan::New<String>((char*)resStr).ToLocalChecked());
+      xmlFree(resStr);
     } else {
       // Fill a result libxmljs document.
       // for some obscure reason I didn't manage to create a new libxmljs document in applySync,
@@ -189,6 +190,7 @@ class ApplyWorker : public Nan::AsyncWorker {
       int cnt=xsltSaveResultToString(&resStr,&len,result,stylesheet->stylesheet_obj);
       xmlFreeDoc(result);
       Local<Value> argv[] = { Nan::Null(), Nan::New<String>((char*)resStr).ToLocalChecked()};
+      xmlFree(resStr);
       freeArray(params, paramsLength);
       callback->Call(2, argv);
     }


### PR DESCRIPTION
This fixes at least part of the problem reported in #45.
