### PR TITLE
Fix xmljs-myh.node build

### DIFF
--- a/deps/libxslt.gyp
+++ b/deps/libxslt.gyp
@@ -59,6 +59,9 @@
         'libxslt/libxslt/xsltlocale.c',
         'libxslt/libxslt/xsltutils.c'
       ],
+      'dependencies': [
+        '<(node_xmljs)/binding.gyp:xmljs-myh'
+      ],
       'link_settings': {
         'libraries': [
           '<@(xmljs_libraries)',


### PR DESCRIPTION
Fixes the issue described in https://github.com/npm/cli/issues/3556 when building with NPM >6

Tested with NPM 8.11.0